### PR TITLE
support unix paths on windows

### DIFF
--- a/cmd/gomarkdoc/command.go
+++ b/cmd/gomarkdoc/command.go
@@ -386,6 +386,10 @@ func getBuildPackage(path string) (*build.Package, error) {
 func getSpecs(paths ...string) []*PackageSpec {
 	var expanded []*PackageSpec
 	for _, path := range paths {
+		// Ensure that the path we're working with is normalized for the OS
+		// we're using (i.e. "\" for windows, "/" for everything else)
+		path = filepath.FromSlash(path)
+
 		// Not a recursive path
 		if !strings.HasSuffix(path, fmt.Sprintf("%s...", string(os.PathSeparator))) {
 			isLocal := isLocalPath(path)

--- a/lang/package.go
+++ b/lang/package.go
@@ -294,8 +294,7 @@ func findImportPath(dir string) (string, bool) {
 		return "", false
 	}
 
-	// TODO: make sure this is valid for all OSes
-	relative = strings.ReplaceAll(relative, "\\", "/")
+	relative = filepath.ToSlash(relative)
 
 	return path.Join(string(m[1]), relative), true
 }


### PR DESCRIPTION
Fixes the outputted import path when using local paths on Windows and using `/` as a path separator instead of the native `\`