### PR TITLE
ci: upgrade release workflow to go 1.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.x
+          go-version: 1.14.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:


### PR DESCRIPTION
The latest version of goreleaser uses golang 1.14 and has target architectures not supported in golang 1.13.