### PR TITLE
feat(lang): show expected output for examples

### DIFF
--- a/lang/README.md
+++ b/lang/README.md
@@ -32,6 +32,7 @@ Package lang provides constructs for defining golang language constructs and ext
   - [func (ex *Example) Level() int](<#func-example-level>)
   - [func (ex *Example) Location() Location](<#func-example-location>)
   - [func (ex *Example) Name() string](<#func-example-name>)
+  - [func (ex *Example) Output() string](<#func-example-output>)
   - [func (ex *Example) Summary() string](<#func-example-summary>)
   - [func (ex *Example) Title() string](<#func-example-title>)
 - [type File](<#type-file>)
@@ -294,6 +295,14 @@ func (ex *Example) Name() string
 ```
 
 Name provides a pretty\-printed name for the specific example\, if one was provided\.
+
+### func \(\*Example\) [Output](<https://github.com/princjef/gomarkdoc/blob/master/lang/example.go#L82>)
+
+```go
+func (ex *Example) Output() string
+```
+
+Output provides the code's example output\.
 
 ### func \(\*Example\) [Summary](<https://github.com/princjef/gomarkdoc/blob/master/lang/example.go#L54>)
 

--- a/lang/README.md
+++ b/lang/README.md
@@ -29,6 +29,7 @@ Package lang provides constructs for defining golang language constructs and ext
   - [func NewExample(cfg *Config, name string, doc *doc.Example) *Example](<#func-newexample>)
   - [func (ex *Example) Code() (string, error)](<#func-example-code>)
   - [func (ex *Example) Doc() *Doc](<#func-example-doc>)
+  - [func (ex *Example) HasOutput() bool](<#func-example-hasoutput>)
   - [func (ex *Example) Level() int](<#func-example-level>)
   - [func (ex *Example) Location() Location](<#func-example-location>)
   - [func (ex *Example) Name() string](<#func-example-name>)
@@ -271,6 +272,14 @@ func (ex *Example) Doc() *Doc
 ```
 
 Doc provides the structured contents of the documentation comment for the example\.
+
+### func \(\*Example\) [HasOutput](<https://github.com/princjef/gomarkdoc/blob/master/lang/example.go#L87>)
+
+```go
+func (ex *Example) HasOutput() bool
+```
+
+HasOutput indicates whether the example contains any example output\.
 
 ### func \(\*Example\) [Level](<https://github.com/princjef/gomarkdoc/blob/master/lang/example.go#L25>)
 

--- a/lang/example.go
+++ b/lang/example.go
@@ -85,5 +85,5 @@ func (ex *Example) Output() string {
 
 // HasOutput indicates whether the example contains any example output.
 func (ex *Example) HasOutput() bool {
-	return ex.doc.Output != "" && !ex.doc.EmptyOutput
+	return ex.doc.Output != "" || ex.doc.EmptyOutput
 }

--- a/lang/example.go
+++ b/lang/example.go
@@ -82,3 +82,8 @@ func (ex *Example) Code() (string, error) {
 func (ex *Example) Output() string {
 	return ex.doc.Output
 }
+
+// HasOutput indicates whether the example contains any example output.
+func (ex *Example) HasOutput() bool {
+	return ex.doc.Output != "" && !ex.doc.EmptyOutput
+}

--- a/lang/example.go
+++ b/lang/example.go
@@ -77,3 +77,8 @@ func (ex *Example) Code() (string, error) {
 
 	return code.String(), nil
 }
+
+// Output provides the code's example output.
+func (ex *Example) Output() string {
+	return ex.doc.Output
+}

--- a/templates.go
+++ b/templates.go
@@ -18,7 +18,11 @@ var templates = map[string]string{
 
 {{- template "doc" .Doc -}}
 
-{{- codeBlock "go" .Code -}}
+{{- codeBlock "go" .Code }}
+
+Output:
+
+{{ codeBlock "output" .Output -}}
 
 {{- accordionTerminator -}}
 

--- a/templates.go
+++ b/templates.go
@@ -18,7 +18,7 @@ var templates = map[string]string{
 
 {{- template "doc" .Doc -}}
 
-{{- codeBlock "go" .Code }}
+{{- codeBlock "go" .Code -}}
 
 {{- if .HasOutput -}}
 

--- a/templates.go
+++ b/templates.go
@@ -20,9 +20,13 @@ var templates = map[string]string{
 
 {{- codeBlock "go" .Code }}
 
-Output:
+{{- if .HasOutput -}}
 
-{{ codeBlock "output" .Output -}}
+	{{- header 4 "Output" -}}
+
+	{{- codeBlock "" .Output -}}
+    
+{{- end -}}
 
 {{- accordionTerminator -}}
 

--- a/templates/example.gotxt
+++ b/templates/example.gotxt
@@ -6,7 +6,7 @@
 
 Output:
 
-{{ codeBlock "output" .Output -}}
+{{ codeBlock "" .Output -}}
 
 {{- accordionTerminator -}}
 

--- a/templates/example.gotxt
+++ b/templates/example.gotxt
@@ -2,7 +2,11 @@
 
 {{- template "doc" .Doc -}}
 
-{{- codeBlock "go" .Code -}}
+{{- codeBlock "go" .Code }}
+
+Output:
+
+{{ codeBlock "output" .Output -}}
 
 {{- accordionTerminator -}}
 

--- a/templates/example.gotxt
+++ b/templates/example.gotxt
@@ -4,9 +4,13 @@
 
 {{- codeBlock "go" .Code }}
 
-Output:
+{{- if .HasOutput -}}
 
-{{ codeBlock "" .Output -}}
+	{{- header 4 "Output" -}}
+
+	{{- codeBlock "" .Output -}}
+    
+{{- end -}}
 
 {{- accordionTerminator -}}
 

--- a/templates/example.gotxt
+++ b/templates/example.gotxt
@@ -2,7 +2,7 @@
 
 {{- template "doc" .Doc -}}
 
-{{- codeBlock "go" .Code }}
+{{- codeBlock "go" .Code -}}
 
 {{- if .HasOutput -}}
 


### PR DESCRIPTION
Closes #26 

This MR includes example output along with the code that generates that output. Given `foo.go`:

```go
package foo

import "fmt"

func Hello(name string) string {
	return fmt.Sprintf("Hello %s!", name)
}
```

and `foo_test.go`:

```go
package foo

import "fmt"

func ExampleHello() {
	fmt.Println(Hello("foo"))
	// Output: Hello foo!
}
```

the output looks like this:

````markdown
<details><summary>Example</summary>
<p>

```go
{
	fmt.Println(Hello("foo"))

}
```



Outputs:

```output
Hello foo!
```

</p>
</details>
````

Note, this MR also includes a `go mod tidy`. This might overlap with #25, so this can be altered if necessary. Additionally, I ended up using the markdown code fence type `output` as a descriptor, but I don't know if there's a better descriptor to use here.