### PR TITLE
ci: switch to official mage action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,17 +21,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Lint
-        uses: crazy-max/ghaction-mage@v1
+        uses: magefile/mage-action@v1
         with:
-          version: 1.9.0
+          version: latest
           args: lint
       - name: Doc Verify
-        uses: crazy-max/ghaction-mage@v1
+        uses: magefile/mage-action@v1
         with:
-          version: 1.9.0
+          version: latest
           args: docVerify
       - name: Test
-        uses: crazy-max/ghaction-mage@v1
+        uses: magefile/mage-action@v1
         with:
-          version: 1.9.0
+          version: latest
           args: test


### PR DESCRIPTION
The existing mage action appears to be malfunctioning in recent builds. This switches to the official mage action that is now available.