### PR TITLE
docs(readme): add GO111MODULE=on to installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Package gomarkdoc formats documentation for one or more packages as markdown for
 If you want to use this package as a command\-line tool\, you can install the command by running:
 
 ```
-go get -u github.com/princjef/gomarkdoc/cmd/gomarkdoc
+GO111MODULE=on go get -u github.com/princjef/gomarkdoc/cmd/gomarkdoc
 ```
 
 The command line tool supports configuration for all of the features of the importable package:

--- a/doc.go
+++ b/doc.go
@@ -9,7 +9,7 @@
 // If you want to use this package as a command-line tool, you can install the
 // command by running:
 //
-//	go get -u github.com/princjef/gomarkdoc/cmd/gomarkdoc
+//	GO111MODULE=on go get -u github.com/princjef/gomarkdoc/cmd/gomarkdoc
 //
 // The command line tool supports configuration for all of the features of the
 // importable package:


### PR DESCRIPTION
The move to the go modules version of blackfriday means that `go get` must run in module mode to install the tool. Setting `GO111MODULE=on` when running the command ensures this for recent versions of golang.

fixes #31 