### PR TITLE
fix(cmd): perform equality check using hashes

### DIFF
--- a/cmd/gomarkdoc/README.md
+++ b/cmd/gomarkdoc/README.md
@@ -15,7 +15,7 @@ See https://github.com/princjef/gomarkdoc for full documentation of this tool\.
 - [type PackageSpec](<#type-packagespec>)
 
 
-## type [PackageSpec](<https://github.com/princjef/gomarkdoc/blob/master/cmd/gomarkdoc/command.go#L29-L43>)
+## type [PackageSpec](<https://github.com/princjef/gomarkdoc/blob/master/cmd/gomarkdoc/command.go#L30-L44>)
 
 PackageSpec defines the data available to the \-\-output option's template\. Information is recomputed for each package generated\.
 

--- a/cmd/gomarkdoc/command_test.go
+++ b/cmd/gomarkdoc/command_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		b1, b2 []byte
+		equal  bool
+	}{
+		{[]byte("abc"), []byte("abc"), true},
+		{[]byte("abc"), []byte("def"), false},
+		{[]byte{}, []byte{}, true},
+		{[]byte("abc"), []byte{}, false},
+		{[]byte{}, []byte("abc"), false},
+	}
+
+	for _, test := range tests {
+		name := fmt.Sprintf(`"%s" == "%s"`, string(test.b1), string(test.b2))
+		if !test.equal {
+			name = fmt.Sprintf(`"%s" != "%s"`, string(test.b1), string(test.b2))
+		}
+
+		t.Run(name, func(t *testing.T) {
+			is := is.New(t)
+
+			eq, err := compare(bytes.NewBuffer(test.b1), bytes.NewBuffer(test.b2))
+			is.NoErr(err)
+
+			is.Equal(eq, test.equal)
+		})
+	}
+}


### PR DESCRIPTION
The existing check logic is custom, complicated and isn't working correctly right now. Simplifying to a hash comparison fixes the issue and makes the code much more maintainable.