### PR TITLE
Added RendererOption `WithTemplateFunctionOverride`

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,11 @@ func main() {
   - [func (out *Renderer) Type(typ *lang.Type) (string, error)](<#func-renderer-type>)
 - [type RendererOption](<#type-rendereroption>)
   - [func WithFormat(format format.Format) RendererOption](<#func-withformat>)
+  - [func WithTemplateFunctionOverride(name string, function interface{}) RendererOption](<#func-withtemplatefunctionoverride>)
   - [func WithTemplateOverride(name, tmpl string) RendererOption](<#func-withtemplateoverride>)
 
 
-## type [Renderer](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L15-L19>)
+## type [Renderer](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L15-L20>)
 
 Renderer provides capabilities for rendering various types of documentation with the configured format and templates\.
 
@@ -214,7 +215,7 @@ type Renderer struct {
 }
 ```
 
-### func [NewRenderer](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L30>)
+### func [NewRenderer](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L31>)
 
 ```go
 func NewRenderer(opts ...RendererOption) (*Renderer, error)
@@ -222,7 +223,7 @@ func NewRenderer(opts ...RendererOption) (*Renderer, error)
 
 NewRenderer initializes a Renderer configured using the provided options\. If nothing special is provided\, the created renderer will use the default set of templates and the GitHubFlavoredMarkdown\.
 
-### func \(\*Renderer\) [Example](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L140>)
+### func \(\*Renderer\) [Example](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L153>)
 
 ```go
 func (out *Renderer) Example(ex *lang.Example) (string, error)
@@ -230,7 +231,7 @@ func (out *Renderer) Example(ex *lang.Example) (string, error)
 
 Example renders an example's documentation to a string\. You can change the rendering of the example by overriding the "example" template or one of the templates it references\.
 
-### func \(\*Renderer\) [File](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L112>)
+### func \(\*Renderer\) [File](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L125>)
 
 ```go
 func (out *Renderer) File(file *lang.File) (string, error)
@@ -238,7 +239,7 @@ func (out *Renderer) File(file *lang.File) (string, error)
 
 File renders a file containing one or more packages to document to a string\. You can change the rendering of the file by overriding the "file" template or one of the templates it references\.
 
-### func \(\*Renderer\) [Func](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L126>)
+### func \(\*Renderer\) [Func](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L139>)
 
 ```go
 func (out *Renderer) Func(fn *lang.Func) (string, error)
@@ -246,7 +247,7 @@ func (out *Renderer) Func(fn *lang.Func) (string, error)
 
 Func renders a function's documentation to a string\. You can change the rendering of the package by overriding the "func" template or one of the templates it references\.
 
-### func \(\*Renderer\) [Package](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L119>)
+### func \(\*Renderer\) [Package](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L132>)
 
 ```go
 func (out *Renderer) Package(pkg *lang.Package) (string, error)
@@ -254,7 +255,7 @@ func (out *Renderer) Package(pkg *lang.Package) (string, error)
 
 Package renders a package's documentation to a string\. You can change the rendering of the package by overriding the "package" template or one of the templates it references\.
 
-### func \(\*Renderer\) [Type](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L133>)
+### func \(\*Renderer\) [Type](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L146>)
 
 ```go
 func (out *Renderer) Type(typ *lang.Type) (string, error)
@@ -262,7 +263,7 @@ func (out *Renderer) Type(typ *lang.Type) (string, error)
 
 Type renders a type's documentation to a string\. You can change the rendering of the type by overriding the "type" template or one of the templates it references\.
 
-## type [RendererOption](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L22>)
+## type [RendererOption](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L23>)
 
 RendererOption configures the renderer's behavior\.
 
@@ -270,7 +271,7 @@ RendererOption configures the renderer's behavior\.
 type RendererOption func(renderer *Renderer) error
 ```
 
-### func [WithFormat](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L102>)
+### func [WithFormat](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L115>)
 
 ```go
 func WithFormat(format format.Format) RendererOption
@@ -278,7 +279,15 @@ func WithFormat(format format.Format) RendererOption
 
 WithFormat changes the renderer to use the format provided instead of the default format\.
 
-### func [WithTemplateOverride](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L88>)
+### func [WithTemplateFunctionOverride](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L106>)
+
+```go
+func WithTemplateFunctionOverride(name string, function interface{}) RendererOption
+```
+
+WithTemplateFunctionOverride allows to override a template function identified by the provided name using the provided function value\.
+
+### func [WithTemplateOverride](<https://github.com/princjef/gomarkdoc/blob/master/renderer.go#L92>)
 
 ```go
 func WithTemplateOverride(name, tmpl string) RendererOption


### PR DESCRIPTION
This option allows to override one template function, by providing a custom function. This way users will be able to easily customize a format configuration without having to create a whole new one.

For example:
```go
package main
import (
    "go/build"
    "fmt"
    "os"
    "github.com/princjef/gomarkdoc"
    "github.com/princjef/gomarkdoc/lang"
    "github.com/princjef/gomarkdoc/logger"
 )

 func main() {
    // Create a renderer to output data
    out, err := gomarkdoc.NewRenderer(
        gomarkdoc.WithTemplateFunctionOverride("bold", func(text string) (string, err) {
            if text == "" {
                return "", nil
            }
            return "<b>" + text + "</b>", nil
        })
    )
    if err != nil {
        panic(err)
    }

    wd, err := os.Getwd()
    if err != nil {
        panic(err)
    }
    buildPkg, err := build.ImportDir(wd, build.ImportComment)
    if err != nil {
        panic(err)
    }

    // Create a documentation package from the build representation of our
    // package.
    log := logger.New(logger.DebugLevel)
    pkg, err := lang.NewPackageFromBuild(log, buildPkg)
    if err != nil {
        panic(err)
    }

    // Write the documentation out to console.
    fmt.Println(out.Package(pkg))
}
```