### PR TITLE
docs(readme): update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ Package gomarkdoc formats documentation for one or more packages as markdown for
 
 ### Command Line Usage
 
-If you want to use this package as a command\-line tool\, you can install the command by running:
+If you want to use this package as a command\-line tool\, you can install the command by running the following on go 1\.16\+:
+
+```
+go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
+```
+
+For older versions of go\, you can install using the following method instead:
 
 ```
 GO111MODULE=on go get -u github.com/princjef/gomarkdoc/cmd/gomarkdoc

--- a/doc.go
+++ b/doc.go
@@ -7,7 +7,11 @@
 // Command Line Usage
 //
 // If you want to use this package as a command-line tool, you can install the
-// command by running:
+// command by running the following on go 1.16+:
+//
+//	go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
+//
+// For older versions of go, you can install using the following method instead:
 //
 //	GO111MODULE=on go get -u github.com/princjef/gomarkdoc/cmd/gomarkdoc
 //


### PR DESCRIPTION
Adds installation instructions with `go install` for golang 1.16+

Fixes #49 