### PR TITLE
fix(lang): compute func example name correctly

### DIFF
--- a/lang/func.go
+++ b/lang/func.go
@@ -89,7 +89,7 @@ func (fn *Func) Examples() (examples []*Example) {
 		case example.Name == fullName:
 			name = ""
 		case strings.HasPrefix(example.Name, underscorePrefix):
-			name = underscorePrefix[len(underscorePrefix):]
+			name = example.Name[len(underscorePrefix):]
 		default:
 			// TODO: better filtering
 			continue


### PR DESCRIPTION
Example names for functions don't properly compute the name of the example if it has a special name because it's being extracted from the prefix, not the full name. This fixes that mistake.

Fixes #47 