### PR TITLE
feat(cmd): add support for build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Flags:
       --repository.default-branch string   Manual override for the git repository URL used in place of automatic detection.
       --repository.path string             Manual override for the path from the root of the git repository used in place of automatic detection.
       --repository.url string              Manual override for the git repository URL used in place of automatic detection.
+      --tags strings                       Set of build tags to apply when choosing which files to include for documentation generation.
   -t, --template stringToString            Custom template string to use for the provided template name instead of the default template. (default [])
       --template-file stringToString       Custom template file to use for the provided template name instead of the default template. (default [])
   -v, --verbose count                      Log additional output from the execution of the command. Can be chained for additional verbosity.
@@ -129,6 +130,12 @@ As with the godoc tool itself\, only exported symbols will be shown in documenta
 
 ```
 gomarkdoc -u -o README.md .
+```
+
+If you would like to include files that are part of a build tag\, you can specify build tags with the \-\-tags flag\. Tags are also supported through GOFLAGS\, though command line and configuration file definitions override tags specified through GOFLAGS\.
+
+```
+gomarkdoc --tags sometag .
 ```
 
 You can also run gomarkdoc in a verification mode with the \-\-check/\-c flag\. This is particularly useful for continuous integration when you want to make sure that a commit correctly updated the generated documentation\. This flag is only supported when the \-\-output/\-o flag is specified\, as the file provided there is what the tool is checking:

--- a/cmd/gomarkdoc/README.md
+++ b/cmd/gomarkdoc/README.md
@@ -15,7 +15,7 @@ See https://github.com/princjef/gomarkdoc for full documentation of this tool\.
 - [type PackageSpec](<#type-packagespec>)
 
 
-## type [PackageSpec](<https://github.com/princjef/gomarkdoc/blob/master/cmd/gomarkdoc/command.go#L30-L44>)
+## type [PackageSpec](<https://github.com/princjef/gomarkdoc/blob/master/cmd/gomarkdoc/command.go#L31-L45>)
 
 PackageSpec defines the data available to the \-\-output option's template\. Information is recomputed for each package generated\.
 

--- a/doc.go
+++ b/doc.go
@@ -38,6 +38,7 @@
 // 	      --repository.default-branch string   Manual override for the git repository URL used in place of automatic detection.
 // 	      --repository.path string             Manual override for the path from the root of the git repository used in place of automatic detection.
 // 	      --repository.url string              Manual override for the git repository URL used in place of automatic detection.
+//	      --tags strings                       Set of build tags to apply when choosing which files to include for documentation generation.
 // 	  -t, --template stringToString            Custom template string to use for the provided template name instead of the default template. (default [])
 // 	      --template-file stringToString       Custom template file to use for the provided template name instead of the default template. (default [])
 // 	  -v, --verbose count                      Log additional output from the execution of the command. Can be chained for additional verbosity.
@@ -136,6 +137,13 @@
 // adding the --include-unexported/-u flag.
 //
 //	gomarkdoc -u -o README.md .
+//
+// If you would like to include files that are part of a build tag, you can
+// specify build tags with the --tags flag. Tags are also supported through
+// GOFLAGS, though command line and configuration file definitions override tags
+// specified through GOFLAGS.
+//
+//	gomarkdoc --tags sometag .
 //
 // You can also run gomarkdoc in a verification mode with the --check/-c flag.
 // This is particularly useful for continuous integration when you want to make


### PR DESCRIPTION
Adds a new `--tags` option for specifying build tags when picking files to include for documentation generation. Also supports use of `GOFLAGS` for specifying build tags (overridden by use of `--tags` or `tags` in the config file).

Fixes #48 