### PR TITLE
ci: update to golang build verion to 1.17 and update linter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Lint

--- a/magefile.go
+++ b/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 
@@ -9,7 +10,7 @@ import (
 
 var linter = bintool.Must(bintool.New(
 	"golangci-lint{{.BinExt}}",
-	"1.40.1",
+	"1.43.0",
 	"https://github.com/golangci/golangci-lint/releases/download/v{{.Version}}/golangci-lint-{{.Version}}-{{.GOOS}}-{{.GOARCH}}{{.ArchiveExt}}",
 ))
 


### PR DESCRIPTION
Updates the precompiled binary to golang 1.17 and updates the version of golangci-lint to its latest (1.43.0)