### PR TITLE
fix(cmd): support embed when running in check mode

### DIFF
--- a/cmd/gomarkdoc/output.go
+++ b/cmd/gomarkdoc/output.go
@@ -55,6 +55,10 @@ func writeOutput(specs []*PackageSpec, opts commandOptions) error {
 			return err
 		}
 
+		if opts.embed && fileName != "" {
+			text = embedContents(log, fileName, text)
+		}
+
 		switch {
 		case fileName == "":
 			fmt.Fprint(os.Stdout, text)
@@ -65,10 +69,6 @@ func writeOutput(specs []*PackageSpec, opts commandOptions) error {
 				return err
 			}
 		default:
-			if opts.embed {
-				text = embedContents(log, fileName, text)
-			}
-
 			if err := writeFile(fileName, text); err != nil {
 				return fmt.Errorf("failed to write output file %s: %w", fileName, err)
 			}


### PR DESCRIPTION
The check will fail when using `gomarkdoc -c -e ...`. This unfortunately breaks support for running gomarkdown in CI (or other hooks).

The issue is that the embedding is not run when `-c` is set. This changes ensures that the embedding takes place as long as `-o ...` is given.