### PR TITLE
fix(cmd): correct permissions of created files and folders

### DIFF
--- a/cmd/gomarkdoc/command_test.go
+++ b/cmd/gomarkdoc/command_test.go
@@ -298,7 +298,7 @@ func TestCommand_embed(t *testing.T) {
 	data, err := os.ReadFile("./embed/README-template.md")
 	is.NoErr(err)
 
-	err = os.WriteFile("./embed/README-test.md", data, 0644)
+	err = os.WriteFile("./embed/README-test.md", data, 0664)
 	is.NoErr(err)
 
 	main()

--- a/cmd/gomarkdoc/output.go
+++ b/cmd/gomarkdoc/output.go
@@ -82,12 +82,12 @@ func writeFile(fileName string, text string) error {
 	folder := filepath.Dir(fileName)
 
 	if folder != "" {
-		if err := os.MkdirAll(folder, 0664); err != nil {
+		if err := os.MkdirAll(folder, 0755); err != nil {
 			return fmt.Errorf("failed to create folder %s: %w", folder, err)
 		}
 	}
 
-	if err := ioutil.WriteFile(fileName, []byte(text), 0755); err != nil {
+	if err := ioutil.WriteFile(fileName, []byte(text), 0664); err != nil {
 		return fmt.Errorf("failed to write file %s: %w", fileName, err)
 	}
 

--- a/magefile.go
+++ b/magefile.go
@@ -29,6 +29,10 @@ func Generate() error {
 	return shellcmd.Command(`go generate .`).Run()
 }
 
+func Build() error {
+	return shellcmd.Command(`go build -o ./bin/gomarkdoc ./cmd/gomarkdoc`).Run()
+}
+
 func Doc() error {
 	return shellcmd.RunAll(
 		`go run ./cmd/gomarkdoc .`,


### PR DESCRIPTION
Fixed incorrect folder permission introduced by the #72. Also added `build` target in mage for development purposes