### PR TITLE
Support new godoc spec enforced by gofmt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,10 @@ name: Release
 on:
   push:
     branches-ignore:
-      - '**'
+      - "**"
     tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*.*'
+      - "v*.*.*"
+      - "v*.*.*-*.*"
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Lint

--- a/format/formatcore/base.go
+++ b/format/formatcore/base.go
@@ -43,7 +43,7 @@ func CodeBlock(code string) string {
 // provided language (or no language if the empty string is provided), using
 // the triple backtick format from GitHub Flavored Markdown.
 func GFMCodeBlock(language, code string) string {
-	return fmt.Sprintf("```%s\n%s\n```\n\n", language, strings.TrimSpace(code))
+	return fmt.Sprintf("```%s\n%s\n```\n\n", language, strings.Trim(code, "\n"))
 }
 
 // Header converts the provided text into a header of the provided level. The
@@ -124,7 +124,7 @@ func GFMAccordionTerminator() string {
 
 // Paragraph formats a paragraph with the provided text as the contents.
 func Paragraph(text string) string {
-	return fmt.Sprintf("%s\n\n", Escape(text))
+	return fmt.Sprintf("%s\n\n", text)
 }
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/princjef/gomarkdoc
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-git/go-git/v5 v5.3.0

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
+	golang.org/x/mod v0.7.0
 	mvdan.cc/xurls/v2 v2.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,8 @@ golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
+golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/lang/config.go
+++ b/lang/config.go
@@ -70,7 +70,8 @@ func NewConfig(log logger.Logger, workDir string, pkgDir string, opts ...ConfigO
 		docPrinter: &comment.Printer{
 			HeadingLevel: 1,
 			// Prevent anchors from being added by godoc printer
-			HeadingID: func(h *comment.Heading) string { return "" },
+			HeadingID:      func(h *comment.Heading) string { return "" },
+			TextCodePrefix: " ",
 		},
 	}
 

--- a/lang/doc.go
+++ b/lang/doc.go
@@ -18,7 +18,7 @@ type Doc struct {
 // documentation conventions.
 func NewDoc(cfg *Config, text string) *Doc {
 	d := cfg.docParser.Parse(text)
-	prt := cfg.docPrinter
+	printer := cfg.docPrinter
 
 	var blocks []*Block
 
@@ -26,14 +26,14 @@ loop:
 	for i := 0; i < len(d.Content); {
 		switch d.Content[i].(type) {
 		case *comment.Heading:
-			markdown := string(prt.Markdown(&comment.Doc{
+			markdown := string(printer.Markdown(&comment.Doc{
 				Links:   d.Links,
 				Content: []comment.Block{d.Content[i]},
 			}))
 			hdr := strings.TrimSpace(strings.TrimLeft(markdown, "#")) // Remove leading '#' as they are added later by gomarkdoc
 			blocks = append(blocks, NewBlock(cfg.Inc(0), HeaderBlock, hdr))
 		case *comment.Code:
-			markdown := string(prt.Markdown(&comment.Doc{
+			markdown := string(printer.Markdown(&comment.Doc{
 				Links:   d.Links,
 				Content: []comment.Block{d.Content[i]},
 			}))
@@ -46,13 +46,13 @@ loop:
 			for i < len(d.Content) {
 				switch d.Content[i].(type) {
 				case *comment.Heading, *comment.Code:
-					blocks = append(blocks, NewBlock(cfg.Inc(0), ParagraphBlock, strings.Trim(string(prt.Markdown(paragraph)), "\n")))
+					blocks = append(blocks, NewBlock(cfg.Inc(0), ParagraphBlock, strings.Trim(string(printer.Markdown(paragraph)), "\n")))
 					continue loop
 				}
 				paragraph.Content = append(paragraph.Content, d.Content[i])
 				i++
 			}
-			blocks = append(blocks, NewBlock(cfg.Inc(0), ParagraphBlock, strings.Trim(string(prt.Markdown(paragraph)), "\n")))
+			blocks = append(blocks, NewBlock(cfg.Inc(0), ParagraphBlock, strings.Trim(string(printer.Markdown(paragraph)), "\n")))
 		}
 		i++
 	}

--- a/lang/doc.go
+++ b/lang/doc.go
@@ -1,7 +1,7 @@
 package lang
 
 import (
-	"regexp"
+	"go/doc/comment"
 	"strings"
 )
 
@@ -12,51 +12,54 @@ type Doc struct {
 	blocks []*Block
 }
 
-var (
-	multilineRegex      = regexp.MustCompile("\n(?:[\t\f ]*\n)+")
-	headerRegex         = regexp.MustCompile(`^[A-Z][^!:;,{}\[\]<>.?]*\n(?:[\t\f ]*\n)`)
-	spaceCodeBlockRegex = regexp.MustCompile(`^(?:(?:(?:(?:  ).*[^\s]+.*)|[\t\f ]*)\n)+`)
-	tabCodeBlockRegex   = regexp.MustCompile(`^(?:(?:(?:\t.*[^\s]+.*)|[\t\f ]*)\n)+`)
-	blankLineRegex      = regexp.MustCompile(`^[\t\f ]*\n`)
-)
-
 // NewDoc initializes a Doc struct from the provided raw documentation text and
 // with headers rendered by default at the heading level provided. Documentation
 // is separated into block level elements using the standard rules from golang's
 // documentation conventions.
 func NewDoc(cfg *Config, text string) *Doc {
-	// Replace CRLF with LF
-	rawText := []byte(normalizeDoc(text) + "\n")
+	d := cfg.docParser.Parse(text)
+	prt := cfg.docPrinter
 
 	var blocks []*Block
-	for len(rawText) > 0 {
-		// Blank lines (ignore)
-		if l, ok := parseBlankLine(rawText); ok {
-			rawText = rawText[l:]
-			continue
-		}
 
-		// Header
-		if b, l, ok := parseHeaderBlock(cfg, rawText); ok {
-			blocks = append(blocks, b)
-			rawText = rawText[l:]
-			continue
+loop:
+	for i := 0; i < len(d.Content); {
+		switch d.Content[i].(type) {
+		case *comment.Heading:
+			markdown := string(prt.Markdown(&comment.Doc{
+				Links:   d.Links,
+				Content: []comment.Block{d.Content[i]},
+			}))
+			hdr := strings.TrimSpace(strings.TrimLeft(markdown, "#")) // Remove leading '#' as they are added later by gomarkdoc
+			blocks = append(blocks, NewBlock(cfg.Inc(0), HeaderBlock, hdr))
+		case *comment.Code:
+			markdown := string(prt.Markdown(&comment.Doc{
+				Links:   d.Links,
+				Content: []comment.Block{d.Content[i]},
+			}))
+			blocks = append(blocks, NewBlock(cfg.Inc(0), CodeBlock, strings.Trim(markdown, "\n")))
+		default:
+			paragraph := &comment.Doc{
+				Links:   d.Links,
+				Content: []comment.Block{},
+			}
+			for i < len(d.Content) {
+				switch d.Content[i].(type) {
+				case *comment.Heading, *comment.Code:
+					blocks = append(blocks, NewBlock(cfg.Inc(0), ParagraphBlock, strings.Trim(string(prt.Markdown(paragraph)), "\n")))
+					continue loop
+				}
+				paragraph.Content = append(paragraph.Content, d.Content[i])
+				i++
+			}
+			blocks = append(blocks, NewBlock(cfg.Inc(0), ParagraphBlock, strings.Trim(string(prt.Markdown(paragraph)), "\n")))
 		}
-
-		// Code block
-		if b, l, ok := parseCodeBlock(cfg, rawText); ok {
-			blocks = append(blocks, b)
-			rawText = rawText[l:]
-			continue
-		}
-
-		// Paragraph
-		b, l := parseParagraph(cfg, rawText)
-		blocks = append(blocks, b)
-		rawText = rawText[l:]
+		i++
 	}
-
-	return &Doc{cfg, blocks}
+	return &Doc{
+		cfg:    cfg,
+		blocks: blocks,
+	}
 }
 
 // Level provides the default level that headers within the documentation should
@@ -69,83 +72,4 @@ func (d *Doc) Level() int {
 // contents.
 func (d *Doc) Blocks() []*Block {
 	return d.blocks
-}
-
-func parseBlankLine(text []byte) (length int, ok bool) {
-	if l := blankLineRegex.Find(text); l != nil {
-		// Ignore blank lines
-		return len(l), true
-	}
-
-	return 0, false
-}
-
-func parseHeaderBlock(cfg *Config, text []byte) (block *Block, length int, ok bool) {
-	if l := headerRegex.Find(text); l != nil {
-		headerText := strings.TrimSpace(string(l))
-		return NewBlock(cfg.Inc(0), HeaderBlock, headerText), len(l), true
-	}
-
-	return nil, 0, false
-}
-
-func parseCodeBlock(cfg *Config, text []byte) (block *Block, length int, ok bool) {
-	l := spaceCodeBlockRegex.Find(text)
-	var indent rune
-	if l != nil {
-		indent = ' '
-	} else {
-		l = tabCodeBlockRegex.Find(text)
-		if l != nil {
-			indent = '\t'
-		} else {
-			return nil, 0, false
-		}
-	}
-
-	lines := strings.Split(string(l), "\n")
-
-	minIndent := -1
-	for _, line := range lines {
-		for i, r := range line {
-			if r != indent && (minIndent == -1 || i < minIndent) {
-				minIndent = i
-			}
-		}
-	}
-
-	var trimmedBlock strings.Builder
-	for i, line := range lines {
-		if i > 0 {
-			trimmedBlock.WriteRune('\n')
-		}
-
-		if len(strings.TrimSpace(line)) > 0 {
-			trimmedBlock.WriteString(line[minIndent:])
-		}
-	}
-
-	return NewBlock(cfg.Inc(0), CodeBlock, trimmedBlock.String()), len(l), true
-}
-
-func parseParagraph(cfg *Config, text []byte) (block *Block, length int) {
-	if loc := multilineRegex.FindIndex(text); loc != nil {
-		// Paragraph followed by something else
-		paragraph := strings.TrimSpace(string(text[:loc[1]]))
-		return NewBlock(cfg.Inc(0), ParagraphBlock, formatDocParagraph(paragraph)), loc[1]
-	}
-
-	// Last paragraph
-	paragraph := strings.TrimSpace(string(text))
-
-	var mergedParagraph strings.Builder
-	for i, line := range strings.Split(paragraph, "\n") {
-		if i > 0 {
-			mergedParagraph.WriteRune(' ')
-		}
-
-		mergedParagraph.WriteString(strings.TrimSpace(line))
-	}
-
-	return NewBlock(cfg.Inc(0), ParagraphBlock, mergedParagraph.String()), len(text)
 }

--- a/lang/func_test.go
+++ b/lang/func_test.go
@@ -2,6 +2,7 @@ package lang_test
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -81,27 +82,24 @@ func TestFunc_Doc(t *testing.T) {
 
 	doc := fn.Doc()
 	blocks := doc.Blocks()
-	is.Equal(len(blocks), 5)
+	is.Equal(len(blocks), 4)
 
 	is.Equal(blocks[0].Kind(), lang.ParagraphBlock)
 	is.Equal(blocks[0].Level(), 3)
-	is.Equal(blocks[0].Text(), "Standalone provides a function that is not part of a type.")
+	is.Equal(blocks[0].Text(), "Standalone provides a function that is not part of a type.\n\nAdditional description can be provided in subsequent paragraphs, including code blocks and headers")
 
-	is.Equal(blocks[1].Kind(), lang.ParagraphBlock)
+	is.Equal(blocks[1].Kind(), lang.HeaderBlock)
 	is.Equal(blocks[1].Level(), 3)
-	is.Equal(blocks[1].Text(), "Additional description can be provided in subsequent paragraphs, including code blocks and headers")
+	is.Equal(blocks[1].Text(), "Header A")
 
-	is.Equal(blocks[2].Kind(), lang.HeaderBlock)
+	is.Equal(blocks[2].Kind(), lang.ParagraphBlock)
 	is.Equal(blocks[2].Level(), 3)
-	is.Equal(blocks[2].Text(), "Header A")
+	fmt.Printf("%q\n", blocks[2].Text())
+	is.Equal(blocks[2].Text(), "This section contains a code block.")
 
-	is.Equal(blocks[3].Kind(), lang.ParagraphBlock)
+	is.Equal(blocks[3].Kind(), lang.CodeBlock)
 	is.Equal(blocks[3].Level(), 3)
-	is.Equal(blocks[3].Text(), "This section contains a code block.")
-
-	is.Equal(blocks[4].Kind(), lang.CodeBlock)
-	is.Equal(blocks[4].Level(), 3)
-	is.Equal(blocks[4].Text(), "Code Block\nMore of Code Block\n")
+	is.Equal(blocks[3].Text(), "\tCode Block\n\tMore of Code Block")
 }
 
 func TestFunc_Location(t *testing.T) {

--- a/lang/package.go
+++ b/lang/package.go
@@ -71,6 +71,8 @@ func NewPackageFromBuild(log logger.Logger, pkg *build.Package, opts ...PackageO
 		return nil, err
 	}
 
+	cfg.docParser = docPkg.Parser() // Overwrite docParser with the one with package scope loaded
+
 	files, err := parsePkgFiles(pkg, cfg.FileSet)
 	if err != nil {
 		return nil, err

--- a/lang/type_test.go
+++ b/lang/type_test.go
@@ -55,8 +55,8 @@ func TestFunc_netHttpResponseWriter(t *testing.T) {
     // Handlers can set HTTP trailers.
     //
     // Changing the header map after a call to WriteHeader (or
-    // Write) has no effect unless the modified headers are
-    // trailers.
+    // Write) has no effect unless the HTTP status code was of the
+    // 1xx class or the modified headers are trailers.
     //
     // There are two ways to set Trailers. The preferred way is to
     // predeclare in the headers which trailers you will later
@@ -101,13 +101,18 @@ func TestFunc_netHttpResponseWriter(t *testing.T) {
     // If WriteHeader is not called explicitly, the first call to Write
     // will trigger an implicit WriteHeader(http.StatusOK).
     // Thus explicit calls to WriteHeader are mainly used to
-    // send error codes.
+    // send error codes or 1xx informational responses.
     //
     // The provided code must be a valid HTTP 1xx-5xx status code.
-    // Only one header may be written. Go does not currently
-    // support sending user-defined 1xx informational headers,
-    // with the exception of 100-continue response header that the
-    // Server sends automatically when the Request.Body is read.
+    // Any number of 1xx headers may be written, followed by at most
+    // one 2xx-5xx header. 1xx headers are sent immediately, but 2xx-5xx
+    // headers may be buffered. Use the Flusher interface to send
+    // buffered data. The header map is cleared when 2xx-5xx headers are
+    // sent, but not with 1xx headers.
+    //
+    // The server will automatically send a 100 (Continue) header
+    // on the first read from the request body if the request has
+    // an "Expect: 100-continue" header.
     WriteHeader(statusCode int)
 }`)
 	is.Equal(len(typ.Examples()), 1)


### PR DESCRIPTION
Hi ! Thanks for this awesome tool. 

As stated in #81 unfortunately, it does not play well with the new godoc spec. Like headers, or links references.

This PR is an attempt to delegate the parsing of docstrings to `go/doc/comment.Parser`, and markdown rendering (escaping) to `go/doc/comment.Printer` as suggested in a comment of #81 

I may have missed things but from the tests I did on a large codebase, it seems to be working quite well.

I also updated to go 1.19

You can give it a try with
```bash
go run github.com/phsym/gomarkdoc/cmd/gomarkdoc@latest
```

Fixes #81