### PR TITLE
ci: improve coverage measurement

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -77,7 +77,7 @@ func RegenerateTestDocs() error {
 }
 
 func Test() error {
-	return shellcmd.Command(`go test -count 1 -coverprofile=coverage.txt . ./cmd/... ./format/... ./lang/... ./logger/...`).Run()
+	return shellcmd.Command(`go test -count 1 -coverpkg=.,./cmd/...,./format/...,./lang/...,./logger/... -cover -coverprofile=coverage.txt ./...`).Run()
 }
 
 func Coverage() error {


### PR DESCRIPTION
The current coverage measurement only tracks intra-package coverage, which is very impractical for something that is best verified through snapshot testing. This changes that pattern to encourage more full system tests