### PR TITLE
Filter config.Files using build tags

### DIFF
--- a/lang/package.go
+++ b/lang/package.go
@@ -61,7 +61,7 @@ func NewPackageFromBuild(log logger.Logger, pkg *build.Package, opts ...PackageO
 		return nil, err
 	}
 
-	cfg, err := NewConfig(log, wd, pkg.Dir, ConfigWithRepoOverrides(options.repositoryOverrides))
+	cfg, err := NewConfig(log, wd, pkg, ConfigWithRepoOverrides(options.repositoryOverrides))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adjusts the `NewConfig()` function to accept a `*build.Package` so that it can use tags to filter files that should not be included in the build.

The intention here is to fix #113 